### PR TITLE
Correctly handle spaces in file paths.

### DIFF
--- a/lib/comet/challenge.rb
+++ b/lib/comet/challenge.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 class Comet::Challenge
   attr_reader :id, :name, :slug, :download_link, :basedir
 
@@ -11,7 +13,7 @@ class Comet::Challenge
 
   def download
     archive = Comet::API.download_archive(download_link, File.join(basedir, "#{slug}.tar.gz"))
-    `tar zxf #{archive} -C #{basedir}`
+    `tar zxf #{Shellwords.escape(archive)} -C #{Shellwords.escape(basedir)}`
     File.delete(archive)
     File.join(basedir, slug)
   end


### PR DESCRIPTION
Previously had an issue when unpacking archives in a path
containing a space. Now when building the shell command to
run `tar` the paths are properly escaped to allow for spaces
(and other special chars if necessary).

Fixes #16.
